### PR TITLE
typos and fix on casci routine

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ pip install -e .
 dyson_orca_tools -i initial.json -f final.json -p params.json
 ```
 
-`params.json` should be a json file with the information contaning the spin CI coeffients
+`params.json` should be a json file with the information containing the spin CI coefficients
 
 Sample input
 
@@ -90,7 +90,7 @@ Here is a recommended configuration:
 }
 ```
 
-After than you can optain json file from the calculations
+After that you can obtain json file from the calculations
 
 ```bash
 orca_2json mol.gbw

--- a/src/dyson_orca_tools/dyson.py
+++ b/src/dyson_orca_tools/dyson.py
@@ -80,12 +80,12 @@ class Dyson:
             if np.sum(diff) == 1:
                 # Electron added in final state
                 idx = np.where(diff == 1)[0][0]
-                sign = (-1) ** np.sum(occ_i[:idx])
+                sign = (-1) ** np.sum(occ_f[:idx])
                 return idx, sign
             elif np.sum(diff) == -1:
                 # Electron removed in final state
                 idx = np.where(diff == -1)[0][0]
-                sign = (-1) ** np.sum(occ_i[:idx])
+                sign = (-1) ** np.sum(occ_f[:idx])
                 return idx, sign
 
         return None, None

--- a/src/dyson_orca_tools/utils.py
+++ b/src/dyson_orca_tools/utils.py
@@ -167,7 +167,7 @@ def sannity_check(neutral_wfn_data: dict, charged_wfn_data: dict):
         )
         raise typer.Exit(1)
 
-    # Check if S-Matrix in in the files
+    # Check if S-Matrix is in the files
 
     if (
         "S-Matrix" not in neutral_wfn_data["Molecule"]


### PR DESCRIPTION
Typos in README and utils.py

In CASCI routine, sign should come from final state (occ_f), where the operator is applied.